### PR TITLE
consume api from jsonplaceholder

### DIFF
--- a/src/main/java/com/irdaislakhuafa/alterraacademyfinalproject/controllers/jsonplaceholder/JPUserController.java
+++ b/src/main/java/com/irdaislakhuafa/alterraacademyfinalproject/controllers/jsonplaceholder/JPUserController.java
@@ -1,20 +1,49 @@
 package com.irdaislakhuafa.alterraacademyfinalproject.controllers.jsonplaceholder;
 
+import javax.validation.Valid;
+
+import com.irdaislakhuafa.alterraacademyfinalproject.model.dtos.jsonplaceholder.requests.FindByEmailRequest;
 import com.irdaislakhuafa.alterraacademyfinalproject.services.consume.JsonPlaceholderUserService;
+import static com.irdaislakhuafa.alterraacademyfinalproject.utils.ApiResponse.*;
+
+import java.util.NoSuchElementException;
+
+import com.irdaislakhuafa.alterraacademyfinalproject.utils.ApiValidation;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.*;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping(value = { "/api/v1/jsonplaceholder/users" })
 public class JPUserController {
-    private final JsonPlaceholderUserService userService;
+    private final JsonPlaceholderUserService jpUserService;
+    private final ApiValidation apiValidation;
 
     @GetMapping
     public ResponseEntity<?> getAll() {
-        return ResponseEntity.ok(userService.findAll());
+        return ResponseEntity.ok(success(jpUserService.findAll()));
+    }
+
+    @GetMapping(value = { "/findBy/email" })
+    public ResponseEntity<?> findByEmail(@RequestBody @Valid FindByEmailRequest request, Errors errors) {
+        if (errors.hasErrors()) {
+            return ResponseEntity.badRequest().body(validationFailed(apiValidation.getErrorMessages(errors)));
+        }
+
+        try {
+            var user = jpUserService.findByEmail(request.getEmail());
+            return ResponseEntity.ok(success(user));
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.badRequest().body(failed(e.getMessage()));
+        } catch (Exception e) {
+            log.error("Error: " + e.getMessage());
+            return ResponseEntity.internalServerError().body(error(e.getMessage()));
+        }
     }
 }

--- a/src/main/java/com/irdaislakhuafa/alterraacademyfinalproject/controllers/jsonplaceholder/JPUserController.java
+++ b/src/main/java/com/irdaislakhuafa/alterraacademyfinalproject/controllers/jsonplaceholder/JPUserController.java
@@ -2,12 +2,17 @@ package com.irdaislakhuafa.alterraacademyfinalproject.controllers.jsonplaceholde
 
 import javax.validation.Valid;
 
-import com.irdaislakhuafa.alterraacademyfinalproject.model.dtos.jsonplaceholder.requests.FindByEmailRequest;
+import com.irdaislakhuafa.alterraacademyfinalproject.model.dtos.jsonplaceholder.requests.*;
+import com.irdaislakhuafa.alterraacademyfinalproject.model.entities.Role;
+import com.irdaislakhuafa.alterraacademyfinalproject.model.entities.User;
+import com.irdaislakhuafa.alterraacademyfinalproject.services.RoleService;
+import com.irdaislakhuafa.alterraacademyfinalproject.services.UserService;
 import com.irdaislakhuafa.alterraacademyfinalproject.services.consume.JsonPlaceholderUserService;
 import static com.irdaislakhuafa.alterraacademyfinalproject.utils.ApiResponse.*;
 
-import java.util.NoSuchElementException;
+import java.util.*;
 
+import com.irdaislakhuafa.alterraacademyfinalproject.utils.ApiResponse;
 import com.irdaislakhuafa.alterraacademyfinalproject.utils.ApiValidation;
 
 import org.springframework.http.ResponseEntity;
@@ -24,6 +29,8 @@ import lombok.extern.slf4j.Slf4j;
 public class JPUserController {
     private final JsonPlaceholderUserService jpUserService;
     private final ApiValidation apiValidation;
+    private final RoleService roleService;
+    private final UserService userService;
 
     @GetMapping
     public ResponseEntity<?> getAll() {
@@ -39,6 +46,43 @@ public class JPUserController {
         try {
             var user = jpUserService.findByEmail(request.getEmail());
             return ResponseEntity.ok(success(user));
+        } catch (NoSuchElementException e) {
+            return ResponseEntity.badRequest().body(failed(e.getMessage()));
+        } catch (Exception e) {
+            log.error("Error: " + e.getMessage());
+            return ResponseEntity.internalServerError().body(error(e.getMessage()));
+        }
+    }
+
+    @PostMapping(value = { "/register" })
+    public ResponseEntity<?> register(@RequestBody @Valid Register register, Errors errors) {
+        if (errors.hasErrors()) {
+            return ResponseEntity.badRequest().body(validationFailed(apiValidation.getErrorMessages(errors)));
+        }
+
+        try {
+            var userJson = this.jpUserService.findByEmail(register.getEmail());
+            var user = User.builder()
+                    .name(userJson.get().getName())
+                    .email(userJson.get().getEmail())
+                    .password(userJson.get().getUsername())
+                    .isEnable(true)
+                    .roles(new HashSet<>(roleService.findByNames("user")))
+                    .build();
+
+            log.info("saving new user");
+            var savedUser = userService.save(user);
+            if (!savedUser.isPresent()) {
+                return ResponseEntity.badRequest().body(failed("failed to save new user, please call IT service"));
+            }
+
+            var response = new HashMap<>() {
+                {
+                    put("message", "your password is username from json placeholder");
+                    put("saved", savedUser);
+                }
+            };
+            return ResponseEntity.ok(success(response));
         } catch (NoSuchElementException e) {
             return ResponseEntity.badRequest().body(failed(e.getMessage()));
         } catch (Exception e) {

--- a/src/main/java/com/irdaislakhuafa/alterraacademyfinalproject/controllers/jsonplaceholder/JPUserController.java
+++ b/src/main/java/com/irdaislakhuafa/alterraacademyfinalproject/controllers/jsonplaceholder/JPUserController.java
@@ -1,0 +1,20 @@
+package com.irdaislakhuafa.alterraacademyfinalproject.controllers.jsonplaceholder;
+
+import com.irdaislakhuafa.alterraacademyfinalproject.services.consume.JsonPlaceholderUserService;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(value = { "/api/v1/jsonplaceholder/users" })
+public class JPUserController {
+    private final JsonPlaceholderUserService userService;
+
+    @GetMapping
+    public ResponseEntity<?> getAll() {
+        return ResponseEntity.ok(userService.findAll());
+    }
+}

--- a/src/main/java/com/irdaislakhuafa/alterraacademyfinalproject/controllers/jsonplaceholder/JPUserController.java
+++ b/src/main/java/com/irdaislakhuafa/alterraacademyfinalproject/controllers/jsonplaceholder/JPUserController.java
@@ -1,18 +1,17 @@
 package com.irdaislakhuafa.alterraacademyfinalproject.controllers.jsonplaceholder;
 
-import javax.validation.Valid;
-
-import com.irdaislakhuafa.alterraacademyfinalproject.model.dtos.jsonplaceholder.requests.*;
-import com.irdaislakhuafa.alterraacademyfinalproject.model.entities.Role;
-import com.irdaislakhuafa.alterraacademyfinalproject.model.entities.User;
-import com.irdaislakhuafa.alterraacademyfinalproject.services.RoleService;
-import com.irdaislakhuafa.alterraacademyfinalproject.services.UserService;
-import com.irdaislakhuafa.alterraacademyfinalproject.services.consume.JsonPlaceholderUserService;
 import static com.irdaislakhuafa.alterraacademyfinalproject.utils.ApiResponse.*;
 
 import java.util.*;
 
-import com.irdaislakhuafa.alterraacademyfinalproject.utils.ApiResponse;
+import javax.validation.Valid;
+
+import com.irdaislakhuafa.alterraacademyfinalproject.model.dtos.jsonplaceholder.requests.FindByEmailRequest;
+import com.irdaislakhuafa.alterraacademyfinalproject.model.dtos.jsonplaceholder.requests.Register;
+import com.irdaislakhuafa.alterraacademyfinalproject.model.entities.User;
+import com.irdaislakhuafa.alterraacademyfinalproject.services.RoleService;
+import com.irdaislakhuafa.alterraacademyfinalproject.services.UserService;
+import com.irdaislakhuafa.alterraacademyfinalproject.services.consume.JsonPlaceholderUserService;
 import com.irdaislakhuafa.alterraacademyfinalproject.utils.ApiValidation;
 
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/irdaislakhuafa/alterraacademyfinalproject/model/dtos/jsonplaceholder/Address.java
+++ b/src/main/java/com/irdaislakhuafa/alterraacademyfinalproject/model/dtos/jsonplaceholder/Address.java
@@ -1,0 +1,16 @@
+package com.irdaislakhuafa.alterraacademyfinalproject.model.dtos.jsonplaceholder;
+
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+public class Address {
+    private String street;
+    private String suite;
+    private String city;
+    private String zipcode;
+}

--- a/src/main/java/com/irdaislakhuafa/alterraacademyfinalproject/model/dtos/jsonplaceholder/Company.java
+++ b/src/main/java/com/irdaislakhuafa/alterraacademyfinalproject/model/dtos/jsonplaceholder/Company.java
@@ -1,0 +1,15 @@
+package com.irdaislakhuafa.alterraacademyfinalproject.model.dtos.jsonplaceholder;
+
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+public class Company {
+    private String name;
+    private String catchPhrase;
+    private String bs;
+}

--- a/src/main/java/com/irdaislakhuafa/alterraacademyfinalproject/model/dtos/jsonplaceholder/Geo.java
+++ b/src/main/java/com/irdaislakhuafa/alterraacademyfinalproject/model/dtos/jsonplaceholder/Geo.java
@@ -1,0 +1,14 @@
+package com.irdaislakhuafa.alterraacademyfinalproject.model.dtos.jsonplaceholder;
+
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+public class Geo {
+    private String lat;
+    private String lng;
+}

--- a/src/main/java/com/irdaislakhuafa/alterraacademyfinalproject/model/dtos/jsonplaceholder/User.java
+++ b/src/main/java/com/irdaislakhuafa/alterraacademyfinalproject/model/dtos/jsonplaceholder/User.java
@@ -1,0 +1,19 @@
+package com.irdaislakhuafa.alterraacademyfinalproject.model.dtos.jsonplaceholder;
+
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+public class User {
+    private Long id;
+    private String name;
+    private String username;
+    private String email;
+    private Address address;
+    private String phone;
+    private String website;
+}

--- a/src/main/java/com/irdaislakhuafa/alterraacademyfinalproject/model/dtos/jsonplaceholder/requests/FindByEmailRequest.java
+++ b/src/main/java/com/irdaislakhuafa/alterraacademyfinalproject/model/dtos/jsonplaceholder/requests/FindByEmailRequest.java
@@ -1,0 +1,19 @@
+package com.irdaislakhuafa.alterraacademyfinalproject.model.dtos.jsonplaceholder.requests;
+
+import javax.validation.constraints.*;
+
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+public class FindByEmailRequest {
+    @NotNull(message = "email cannot be null")
+    @NotEmpty(message = "email cannot be empty")
+    @NotBlank(message = "email cannot be blank")
+    @Email(message = "email is not valid")
+    private String email;
+}

--- a/src/main/java/com/irdaislakhuafa/alterraacademyfinalproject/model/dtos/jsonplaceholder/requests/Register.java
+++ b/src/main/java/com/irdaislakhuafa/alterraacademyfinalproject/model/dtos/jsonplaceholder/requests/Register.java
@@ -1,0 +1,24 @@
+package com.irdaislakhuafa.alterraacademyfinalproject.model.dtos.jsonplaceholder.requests;
+
+import javax.validation.constraints.*;
+
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder
+public class Register {
+    @NotNull(message = "username cannot be null")
+    @NotEmpty(message = "username cannot be empty")
+    @NotBlank(message = "username cannot be blank")
+    private String username;
+
+    @NotNull(message = "email cannot be null")
+    @NotEmpty(message = "email cannot be empty")
+    @NotBlank(message = "email cannot be blank")
+    @Email(message = "email is not valid")
+    private String email;
+}

--- a/src/main/java/com/irdaislakhuafa/alterraacademyfinalproject/security/SecurityConfiguration.java
+++ b/src/main/java/com/irdaislakhuafa/alterraacademyfinalproject/security/SecurityConfiguration.java
@@ -43,6 +43,9 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
                 // swagger docs and init (PermitAll)
                 .antMatchers(
+                        // json placeholder
+                        "/api/v1/jsonplaceholder/users",
+
                         // init
                         "/",
                         BASE_URL + "/hello-world",

--- a/src/main/java/com/irdaislakhuafa/alterraacademyfinalproject/security/SecurityConfiguration.java
+++ b/src/main/java/com/irdaislakhuafa/alterraacademyfinalproject/security/SecurityConfiguration.java
@@ -44,7 +44,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 // swagger docs and init (PermitAll)
                 .antMatchers(
                         // json placeholder
-                        "/api/v1/jsonplaceholder/users",
+                        "/api/v1/jsonplaceholder/users/**",
 
                         // init
                         "/",

--- a/src/main/java/com/irdaislakhuafa/alterraacademyfinalproject/services/consume/JsonPlaceholderUserService.java
+++ b/src/main/java/com/irdaislakhuafa/alterraacademyfinalproject/services/consume/JsonPlaceholderUserService.java
@@ -22,8 +22,8 @@ public class JsonPlaceholderUserService {
     private String jsonPlaceholderUserUrl;
 
     public List<User> findAll() {
-        List<User> list = (List<User>) restTemplate.getForObject(jsonPlaceholderUserUrl, Object.class);
-        return list;
+        var list = restTemplate.getForObject(jsonPlaceholderUserUrl, User[].class);
+        return Arrays.asList(list);
     }
 
     public Optional<User> findByEmail(String email) throws NoSuchElementException {

--- a/src/main/java/com/irdaislakhuafa/alterraacademyfinalproject/services/consume/JsonPlaceholderUserService.java
+++ b/src/main/java/com/irdaislakhuafa/alterraacademyfinalproject/services/consume/JsonPlaceholderUserService.java
@@ -1,8 +1,10 @@
 package com.irdaislakhuafa.alterraacademyfinalproject.services.consume;
 
-import java.util.List;
+import java.util.*;
 
 import javax.transaction.Transactional;
+
+import com.irdaislakhuafa.alterraacademyfinalproject.model.dtos.jsonplaceholder.User;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -19,8 +21,16 @@ public class JsonPlaceholderUserService {
     @Value(value = "${json.placeholder.users}")
     private String jsonPlaceholderUserUrl;
 
-    public List<?> findAll() {
-        List<Object> list = (List<Object>) restTemplate.getForObject(jsonPlaceholderUserUrl, Object.class);
+    public List<User> findAll() {
+        List<User> list = (List<User>) restTemplate.getForObject(jsonPlaceholderUserUrl, Object.class);
         return list;
+    }
+
+    public Optional<User> findByEmail(String email) throws NoSuchElementException {
+        var user = this.findAll().stream().filter(u -> u.getEmail().equalsIgnoreCase(email)).findFirst();
+        if (!user.isPresent()) {
+            throw new NoSuchElementException("user with email: " + email + " not found in jsonplaceholder");
+        }
+        return user;
     }
 }

--- a/src/main/java/com/irdaislakhuafa/alterraacademyfinalproject/services/consume/JsonPlaceholderUserService.java
+++ b/src/main/java/com/irdaislakhuafa/alterraacademyfinalproject/services/consume/JsonPlaceholderUserService.java
@@ -1,0 +1,26 @@
+package com.irdaislakhuafa.alterraacademyfinalproject.services.consume;
+
+import java.util.List;
+
+import javax.transaction.Transactional;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class JsonPlaceholderUserService {
+    private final RestTemplate restTemplate;
+
+    @Value(value = "${json.placeholder.users}")
+    private String jsonPlaceholderUserUrl;
+
+    public List<?> findAll() {
+        List<Object> list = (List<Object>) restTemplate.getForObject(jsonPlaceholderUserUrl, Object.class);
+        return list;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -18,3 +18,5 @@ springfox.documentation.swagger-ui.base-url=/api/v1/docs
 app.key.secret=secret
 
 app.base.url=/api/v1
+
+json.placeholder.users=https://jsonplaceholder.typicode.com/users

--- a/src/test/java/com/irdaislakhuafa/alterraacademyfinalproject/services/consume/JsonPlaceholderUserServiceTest.java
+++ b/src/test/java/com/irdaislakhuafa/alterraacademyfinalproject/services/consume/JsonPlaceholderUserServiceTest.java
@@ -1,0 +1,63 @@
+package com.irdaislakhuafa.alterraacademyfinalproject.services.consume;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.NoSuchElementException;
+
+import com.irdaislakhuafa.alterraacademyfinalproject.SimpleTestNameGenerator;
+import com.irdaislakhuafa.alterraacademyfinalproject.model.dtos.jsonplaceholder.User;
+
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.web.client.RestTemplate;
+
+@DisplayNameGeneration(value = SimpleTestNameGenerator.class)
+@Tag(value = "jsonPlaceholderUserServiceTest")
+@SpringBootTest
+public class JsonPlaceholderUserServiceTest {
+    @MockBean
+    private RestTemplate restTemplate;
+
+    private String url = "https://jsonplaceholder.typicode.com/users";
+
+    @Autowired
+    private JsonPlaceholderUserService jpUserService;
+
+    private final User user = User.builder()
+            .name("irda islakhu afa")
+            .username("irdaislakhuafa")
+            .email("irdhaislakhuafa@gmail.com")
+            .build();
+
+    @Test
+    public void testFindAllSuccess() {
+        when(restTemplate.getForObject(url, User[].class))
+                .thenReturn(Arrays.asList(user).toArray(new User[1]));
+
+        var result = jpUserService.findAll();
+        assertNotNull(result);
+        assertEquals(1, result.size());
+    }
+
+    @Test
+    public void testFindByEmailSuccess() {
+        when(restTemplate.getForObject(url, User[].class))
+                .thenReturn(Arrays.asList(user).toArray(new User[1]));
+
+        var result = jpUserService.findByEmail(user.getEmail());
+        assertNotNull(result);
+        assertTrue(result.isPresent());
+    }
+
+    @Test
+    public void testFindByEmailFailed() {
+        when(restTemplate.getForObject(url, User[].class))
+                .thenReturn(Arrays.asList(user).toArray(new User[1]));
+        assertThrows(NoSuchElementException.class, () -> jpUserService.findByEmail("emailNotFound@gmail.com"));
+    }
+}


### PR DESCRIPTION
- define JsonPlaceholderUserService
- create simple endpoint for jsonplaceholder user
- permit all to access jsonplaceholder users api
- create dto to consume response from jsonplaceholder
- add service to find by email
- add conversion from response object to user[] and add endpoint to find user by email in jsonplaceholder
- add register from with account from jsonplaceholder
- remove unused imports
- add unit test for JsonPlaceholderUserService
